### PR TITLE
Fix missing error rejection in image loader

### DIFF
--- a/src/app/theme/services/baImageLoader/baImageLoader.service.ts
+++ b/src/app/theme/services/baImageLoader/baImageLoader.service.ts
@@ -11,6 +11,9 @@ export class BaImageLoaderService {
       img.onload = function() {
         resolve('Image with src ' + src + ' loaded successfully.');
       };
+      img.onerror = function(error) {
+        reject('Error loading image with src ' + src);
+      };
     });
   }
 }


### PR DESCRIPTION
## Summary
- improve reliability of `BaImageLoaderService` by rejecting the Promise when an image fails to load

## Testing
- `npm test` *(fails: `tslint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812d342e6c8327ac8f6947f0221fcd